### PR TITLE
Ensure that generated initPolarisLib() functions use the correct names of the generated type

### DIFF
--- a/ts/libs/polaris-nx/src/generators/elasticity-strategy/generator.ts
+++ b/ts/libs/polaris-nx/src/generators/elasticity-strategy/generator.ts
@@ -73,7 +73,7 @@ function normalizeOptions(host: Tree, options: ElasticityStrategyGeneratorSchema
 
     return {
         names: normalizedNames,
-        className: `${normalizedNames.className}`,
+        className: eStratNames.eStratType,
         projectName: options.project,
         projectSrcRoot: projectConfig.sourceRoot,
         destDir: joinPathFragments('lib', options.directory),

--- a/ts/libs/polaris-nx/src/generators/slo-mapping-type/lib/normalize-options.ts
+++ b/ts/libs/polaris-nx/src/generators/slo-mapping-type/lib/normalize-options.ts
@@ -9,7 +9,7 @@ export function normalizeOptions(host: Tree, options: SloMappingTypeGeneratorSch
 
     return {
         names: normalizedNames,
-        className: `${normalizedNames.className}SloMapping`,
+        className: sloNames.sloMappingType,
         projectName: options.project,
         projectSrcRoot: projectConfig.sourceRoot,
         destDir: joinPathFragments('lib', options.directory),


### PR DESCRIPTION
… regardless whether the user specified a suffix or not

## Pull Request Checklist

Please ensure that you have completed the following tasks:

- [x] Verified that all libraries and applications build successfully.
- [x] Updated the changelog.
- [x] Updated all relevant `*.md` files in `docs`.
- [x] Rebuilt the typedoc docs.
