### PR TITLE
Explicitly handle invalid composed metric values in the Prometheus `ComposedMetricsManager`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 ### Bugfixes
 
 * Ensure that the polaris-cli exists with an error code if an error occurs during execution.
-* Added missing `js-yaml` v4.1.0 as a dependency of `@polaris-sloc/schema-gen`. 
+* Explicitly handle invalid composed metric values in the Prometheus `ComposedMetricsManager`.
+* Added missing `js-yaml` v4.1.0 as a dependency of `@polaris-sloc/schema-gen`.
 
 
 

--- a/ts/libs/core/src/lib/composed-metrics/public/control/impl/default-composed-metrics-manager.ts
+++ b/ts/libs/core/src/lib/composed-metrics/public/control/impl/default-composed-metrics-manager.ts
@@ -110,6 +110,7 @@ export class DefaultComposedMetricsManager implements ComposedMetricsManager, Mo
             throw new ComposedMetricMappingError(
                 'Cannot add Composed Metric, because an instance of it already exists.',
                 mapping,
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                 computationConfig.metricType,
             );
         }
@@ -167,6 +168,11 @@ export class DefaultComposedMetricsManager implements ComposedMetricsManager, Mo
             );
             metricValue$.subscribe({
                 next: value => {
+                    if (!value) {
+                        // eslint-disable-next-line max-len
+                        Logger.log(`Skipping invalid value returned by MetricSource ${activeMetric.mapping?.metadata?.namespace}.${activeMetric.mapping?.metadata?.name}:`, value);
+                        return;
+                    }
                     activeMetric.collectors.forEach(
                         collector => executeSafely(() => collector.collect(value)),
                     );


### PR DESCRIPTION
## Pull Request Checklist

Please ensure that you have completed the following tasks:

- [x] Updated the changelog.
- [x] Updated all relevant `*.md` files in `docs`.

After merging to the `master` branch, ensure that you [update the gh-pages branch](https://github.com/polaris-slo-cloud/polaris#maintaining-gh-pages).
