### PR TITLE
Update docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -141,7 +141,7 @@ For details, on how to build, run and debug the Polaris components, please see t
 ## Deployment
 
 You need a running Kubernetes cluster with a Prometheus installation to use Polaris.
-Instructions on setting up such a cluster can be found [here](./docs/deployment/#prerequisites).
+Instructions on setting up such a cluster can be found [here](./deployment/#prerequisites).
 
 To quickly deploy the default set of elasticity strategies shipped with Polaris, open a terminal in the root folder of the repository and execute the following command:
 


### PR DESCRIPTION
Fixes the link to deployment from the landing page (root already in docs folder).
  I did _not_ update the changelog yet - do you think this is necessary for a docs "bugfix"?

## Pull Request Checklist

Please ensure that you have completed the following tasks:

- [ ] Updated the changelog.
- [x] Updated all relevant `*.md` files in `docs`.

After merging to the `master` branch, ensure that you [update the gh-pages branch](https://github.com/polaris-slo-cloud/polaris#maintaining-gh-pages).
