### PR TITLE
Fix controller.metrics.service.annotations for the nginx ingress in the default testbed

### DIFF
--- a/testbeds/kubernetes/microk8s/base/ingress-nginx/values.yaml
+++ b/testbeds/kubernetes/microk8s/base/ingress-nginx/values.yaml
@@ -649,9 +649,9 @@ controller:
     enabled: true
 
     service:
-      annotations: {}
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "10254"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "10254"
 
       # clusterIP: ""
 


### PR DESCRIPTION
As mentioned in the [kubernetes ingress-nginx docs](https://kubernetes.github.io/ingress-nginx/user-guide/monitoring/)
```
prometheus.io/scrape: "true"
prometheus.io/port: "10254"
```
should be annotations.

This PR fixes this for the base testbed.

## Pull Request Checklist

Please ensure that you have completed the following tasks:

- [ ] Updated the changelog.
- [ ] Updated all relevant `*.md` files in `docs`.

After merging to the `master` branch, ensure that you [update the gh-pages branch](https://github.com/polaris-slo-cloud/polaris#maintaining-gh-pages).
