### PR TITLE
Add histogram quantile support to core/raw-metrics-query and the prometheus adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Polaris SLO Cloud Changelog
 
+## v0.5.0 (unreleased)
+
+* Add histogram quantile support to core/raw-metrics-query and the prometheus adapter
 
 ## v0.4.1 (2022-07-11)
 

--- a/ts/libs/core/src/lib/raw-metrics-query/public/time-series/execution/db-functions.ts
+++ b/ts/libs/core/src/lib/raw-metrics-query/public/time-series/execution/db-functions.ts
@@ -3,4 +3,4 @@
  * Ensures unified naming for DB-native functions.
  */
 // eslint-disable-next-line no-shadow
-export type DBFunctionName = 'rate' | 'averageOverTime'; // ToDo: extend
+export type DBFunctionName = 'rate' | 'averageOverTime' | 'histogramQuantile'; // ToDo: extend

--- a/ts/libs/core/src/lib/raw-metrics-query/public/time-series/execution/impl/time-instant-query.base.ts
+++ b/ts/libs/core/src/lib/raw-metrics-query/public/time-series/execution/impl/time-instant-query.base.ts
@@ -15,6 +15,7 @@ import {
     FilterOnValueQueryContent,
     QueryContentType,
     createQueryContent,
+    HistogramQuantileQueryContent,
 } from '../query-content';
 import { TimeSeriesQueryBase } from './time-series-query.base';
 
@@ -146,6 +147,15 @@ export abstract class TimeInstantQueryBase<T> extends TimeSeriesQueryBase<TimeSe
             contentType: QueryContentType.FilterOnValue,
             filter: predicate,
         };
+        return this.createTimeInstantQuery(queryContent);
+    }
+
+    histogramQuantile(quantile: number): TimeInstantQuery<T> {
+        const queryContent: HistogramQuantileQueryContent = {
+            contentType: QueryContentType.HistogramQuantile,
+            quantile,
+            functionName: 'histogramQuantile'
+        }
         return this.createTimeInstantQuery(queryContent);
     }
 

--- a/ts/libs/core/src/lib/raw-metrics-query/public/time-series/execution/query-content.ts
+++ b/ts/libs/core/src/lib/raw-metrics-query/public/time-series/execution/query-content.ts
@@ -43,6 +43,10 @@ export enum QueryContentType {
      */
     Function = 'functionQuery',
 
+    /**
+     * Calculates the quantile of a histogram.
+     */
+    HistogramQuantile = 'histogramQuantileQuery',
 }
 
 /**
@@ -170,6 +174,17 @@ export interface AggregateByGroupQueryContent extends QueryContent {
 
 }
 
+export interface HistogramQuantileQueryContent extends QueryContent {
+
+    contentType: QueryContentType.HistogramQuantile;
+
+    /**
+     * The quantile to calculate. This must be a value between 0 and 100.
+     */
+    quantile: number;
+
+    functionName: DBFunctionName;
+}
 
 /**
  * Maps the QueryContentTypes to their respective interfaces.
@@ -181,8 +196,9 @@ export interface QueryContentTypeMapping {
     binaryOperationQuery: BinaryOperationQueryContent;
     binaryOperationWithConstOperandQuery: BinaryOperationWithConstOperandQueryContent;
     changeResolutionQuery: ChangeResolutionQueryContent;
-    functionQuery: FunctionQueryContent
+    functionQuery: FunctionQueryContent;
     aggregateByGroupQuery: AggregateByGroupQueryContent;
+    histogramQuantileQuery: HistogramQuantileQueryContent;
 }
 
 /**

--- a/ts/libs/core/src/lib/raw-metrics-query/public/time-series/query-model/time-instant-query.ts
+++ b/ts/libs/core/src/lib/raw-metrics-query/public/time-series/query-model/time-instant-query.ts
@@ -199,6 +199,13 @@ export interface TimeInstantQuery<T> extends ValueFilterableQuery<TimeSeriesInst
      */
     maxByGroup(groupingConfig?: LabelGroupingConfig): TimeInstantQuery<number>;
 
+    /**
+     * Calculates the `quantile` from a histgoram.
+     *
+     * @param quantile The quantile to calculate. Must be between 0 and 100.
+     * @returns A `TimeInstantQuery` with the quantile value from the histogram.
+     */
+    histogramQuantile(quantile: number): TimeInstantQuery<T>
 }
 
 /**


### PR DESCRIPTION
This PR adds support for histogram quantile queries.

[In Prometheus, the `histogram_quantile` function](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) takes a `quantile` (number between 0 and 1), and an instant vection (see also [Prometheus: Querying basics](https://prometheus.io/docs/prometheus/latest/querying/basics/)).
Thus, I only added the `histogramQuantile` function to `TimeInstantQuery`, not the `TimeRangeQuery` (as this would be a range vector in Prometheus).

This implementation is based on [this commit from the nicobargit/polaris fork](https://github.com/polaris-slo-cloud/polaris/commit/cd94b220282e000c65ecafe6279011f2d58d7f0c).

## Pull Request Checklist

Please ensure that you have completed the following tasks:

- [x] Updated the changelog.
- [x] Updated all relevant `*.md` files in `docs`.

After merging to the `master` branch, ensure that you [update the gh-pages branch](https://github.com/polaris-slo-cloud/polaris#maintaining-gh-pages).
